### PR TITLE
Remove include KCIKantanPluginInstallation

### DIFF
--- a/Source/KantanChartsEditor/Private/KantanChartsEditorModule.cpp
+++ b/Source/KantanChartsEditor/Private/KantanChartsEditorModule.cpp
@@ -17,7 +17,7 @@
 #include "PropertyEditorModule.h"
 #include "ClassIconFinder.h"
 
-#include "KCIKantanPluginInstallation.h"
+
 
 
 class FKantanChartsEditorModule : public FDefaultModuleImpl


### PR DESCRIPTION
It fails on building Editor because of this include.

I saw that you have done a commit on "Remove Imported Kantan charts", that you removed this line, but it returned when you merged to master.

Also, if it is possible, it would be nice if you commit these changes on 4.20, because it is working on build 4.20.3, with no warnings or errors, and I am using this branch of your repo to guarantee that nothing will break.

Thank, great work!