### PR TITLE
Unreal 5.1 compile fixes

### DIFF
--- a/Source/KantanChartsEditor/Private/CartesianAxisConfigCustomization.cpp
+++ b/Source/KantanChartsEditor/Private/CartesianAxisConfigCustomization.cpp
@@ -24,7 +24,6 @@ void FCartesianAxisInstanceConfigCustomization::CustomizeHeader(TSharedRef<IProp
 	static const FName MarkersPropertyName = GET_MEMBER_NAME_CHECKED(FCartesianAxisInstanceConfig, bShowMarkers);
 	static const FName LabelsPropertyName = GET_MEMBER_NAME_CHECKED(FCartesianAxisInstanceConfig, bShowLabels);
 
-	const bool bDisplayResetToDefault = false;
 	const FText DisplayNameOverride = FText::GetEmpty();
 	const FText DisplayToolTipOverride = FText::GetEmpty();
 
@@ -66,7 +65,7 @@ void FCartesianAxisInstanceConfigCustomization::CustomizeHeader(TSharedRef<IProp
 			]
 			+ SHorizontalBox::Slot().Padding(4.0f, 0.0f)
 			[
-				StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride, bDisplayResetToDefault)
+				StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride)
 			]
 		];
 			
@@ -103,7 +102,6 @@ TSharedRef< IPropertyTypeCustomization > FCartesianAxisConfigCustomization::Make
 
 void FCartesianAxisConfigCustomization::CustomizeHeader(TSharedRef<IPropertyHandle> StructPropertyHandle, FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils)
 {
-	const bool bDisplayResetToDefault = false;
 	const FText DisplayNameOverride = FText::GetEmpty();
 	const FText DisplayToolTipOverride = FText::GetEmpty();
 
@@ -113,7 +111,7 @@ void FCartesianAxisConfigCustomization::CustomizeHeader(TSharedRef<IPropertyHand
 	HeaderRow
 		.NameContent()
 		[
-			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride, bDisplayResetToDefault)
+			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride)
 		]
 		.ValueContent()
 		[
@@ -182,7 +180,6 @@ TSharedRef< IPropertyTypeCustomization > FCartesianRangeBoundCustomization::Make
 
 void FCartesianRangeBoundCustomization::CustomizeHeader(TSharedRef<IPropertyHandle> StructPropertyHandle, FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils)
 {
-	const bool bDisplayResetToDefault = false;
 	const FText DisplayNameOverride = FText::GetEmpty();
 	const FText DisplayToolTipOverride = FText::GetEmpty();
 
@@ -192,7 +189,7 @@ void FCartesianRangeBoundCustomization::CustomizeHeader(TSharedRef<IPropertyHand
 	HeaderRow
 		.NameContent()
 		[
-			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride, bDisplayResetToDefault)
+			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride)
 		]
 		.ValueContent()
 		.HAlign(EHorizontalAlignment::HAlign_Fill)

--- a/Source/KantanChartsEditor/Private/DetailHelpers.cpp
+++ b/Source/KantanChartsEditor/Private/DetailHelpers.cpp
@@ -112,7 +112,7 @@ namespace DetailHelpers {
 			[
 				// Show the name of the asset or actor
 				SNew(STextBlock)
-				.Font(FEditorStyle::GetFontStyle(TEXT("PropertyWindow.NormalFont")))
+				.Font(FAppStyle::GetFontStyle(TEXT("PropertyWindow.NormalFont")))
 				.Text_Lambda(OnGetCurrentName)
 			];
 

--- a/Source/KantanChartsEditor/Private/DetailHelpers.cpp
+++ b/Source/KantanChartsEditor/Private/DetailHelpers.cpp
@@ -65,7 +65,7 @@ namespace DetailHelpers {
 
 			FAssetPickerConfig AssetPickerConfig;
 			// We want any valid object implementing the interface, so any child of UObject as the filter
-			AssetPickerConfig.Filter.ClassNames.Add(UObject::StaticClass()->GetFName());
+			AssetPickerConfig.Filter.ClassPaths.Add(UObject::StaticClass()->GetClassPathName());
 			// Allow child classes
 			AssetPickerConfig.Filter.bRecursiveClasses = true;
 			// Set a delegate for setting the asset from the picker

--- a/Source/KantanChartsEditor/Private/KantanCartesianPlotScaleCustomization.cpp
+++ b/Source/KantanChartsEditor/Private/KantanCartesianPlotScaleCustomization.cpp
@@ -21,7 +21,6 @@ void FKantanCartesianPlotScaleCustomization::CustomizeHeader(TSharedRef<IPropert
 {
 	static const FName ScalingTypePropertyName = GET_MEMBER_NAME_CHECKED(FKantanCartesianPlotScale, Type);
 
-	const bool bDisplayResetToDefault = false;
 	const FText DisplayNameOverride = FText::GetEmpty();
 	const FText DisplayToolTipOverride = FText::GetEmpty();
 
@@ -40,7 +39,7 @@ void FKantanCartesianPlotScaleCustomization::CustomizeHeader(TSharedRef<IPropert
 	HeaderRow
 		.NameContent()
 		[
-			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride, bDisplayResetToDefault)
+			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride)
 		]
 		.ValueContent()
 		[
@@ -105,7 +104,6 @@ void FCartesianAxisRangeCustomization::CustomizeHeader(TSharedRef<IPropertyHandl
 	static const FName RangeMinPropertyName = GET_MEMBER_NAME_CHECKED(FCartesianAxisRange, Min);
 	static const FName RangeMaxPropertyName = GET_MEMBER_NAME_CHECKED(FCartesianAxisRange, Max);
 
-	const bool bDisplayResetToDefault = false;
 	const FText DisplayNameOverride = FText::GetEmpty();
 	const FText DisplayToolTipOverride = FText::GetEmpty();
 
@@ -117,7 +115,7 @@ void FCartesianAxisRangeCustomization::CustomizeHeader(TSharedRef<IPropertyHandl
 	HeaderRow
 		.NameContent()
 		[
-			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride, bDisplayResetToDefault)
+			StructPropertyHandle->CreatePropertyNameWidget(DisplayNameOverride, DisplayToolTipOverride)
 		]
 		.ValueContent()
 		.MinDesiredWidth(125.0f * 2)


### PR DESCRIPTION
Various fixes for compatibility with Unreal 5.1:
* Error: `FEditorStyle` is now `FAppStyle`
* Deprecation warnings: Usage of `bDisplayResetToDefault` which is no longer used as an argument to `CreatePropertyNameWidget`
* Deprecation warning: Usage of `ClassNames` for the asset picker filter, `ClassPaths` is preferred now