### PR TITLE
Fixed 5.7 build error

### DIFF
--- a/Source/KantanChartsSlate/Private/Charts/CustomDataSeriesElement.cpp
+++ b/Source/KantanChartsSlate/Private/Charts/CustomDataSeriesElement.cpp
@@ -158,7 +158,7 @@ void FCustomDataSeriesElement::DrawRenderThread(FRHICommandListImmediate& RHICmd
 		ClippingRect.Max.X,
 		ClippingRect.Max.Y
 		);
-	RenderTarget->SetRenderTargetTexture(*(FTexture2DRHIRef*)InWindowBackBuffer);
+	RenderTarget->SetRenderTargetTexture(*(FTextureRHIRef*)InWindowBackBuffer);
 	{
 		// Check realtime mode for whether to pass current time to canvas
 		const float RealTime = FApp::GetCurrentTime();

--- a/Source/KantanChartsSlate/Private/SimpleRenderTarget.h
+++ b/Source/KantanChartsSlate/Private/SimpleRenderTarget.h
@@ -19,7 +19,7 @@ public:
 	}
 
 	/** Sets the texture that this target renders to */
-	void SetRenderTargetTexture(FTexture2DRHIRef& InRHIRef)
+	void SetRenderTargetTexture(FTextureRHIRef& InRHIRef)
 	{
 		RenderTargetTextureRHI = InRHIRef;
 	}


### PR DESCRIPTION
Title says it all.

`FTexture2DRHIRef` was deprecated in favor of `FTextureRHIRef`.